### PR TITLE
Cache events and send all then whenever a new client connects

### DIFF
--- a/jashing/src/main/java/com/github/avarabyeu/jashing/core/eventsource/annotation/NoCache.java
+++ b/jashing/src/main/java/com/github/avarabyeu/jashing/core/eventsource/annotation/NoCache.java
@@ -1,0 +1,12 @@
+package com.github.avarabyeu.jashing.core.eventsource.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Defines an event for load up cache eviction
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface NoCache {
+}


### PR DESCRIPTION
When the server starts up all event sources run, but, if some client is not connected to events source, it misses these events.
This implementation caches those events by ID and send them whenever a new client connect.

Maybe my code isn't very well polished, please consider improving it.