### PR TITLE
Use BCEL for classpath annotation scanning.

### DIFF
--- a/jashing/pom.xml
+++ b/jashing/pom.xml
@@ -82,6 +82,12 @@
             <artifactId>wro4j-extensions</artifactId>
             <version>1.8.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.bcel</groupId>
+            <artifactId>bcel</artifactId>
+            <version>6.0</version>
+        </dependency>
     </dependencies>
 
 


### PR DESCRIPTION
This modification intends a better performance for classpath scanning,
without loading all classes just to find the annotated ones.