### PR TITLE
Remove generic type from sendEvent

### DIFF
--- a/jashing/src/main/java/com/github/avarabyeu/jashing/core/eventsource/ScheduledEventSource.java
+++ b/jashing/src/main/java/com/github/avarabyeu/jashing/core/eventsource/ScheduledEventSource.java
@@ -61,7 +61,7 @@ public abstract class ScheduledEventSource<T extends JashingEvent> extends Abstr
     }
 
 
-    protected final void sendEvent(T t) {
+    protected final void sendEvent(JashingEvent t) {
         if (null != t) {
             t.setId(eventId);
             this.eventBus.post(t);

--- a/jashing/src/main/java/com/github/avarabyeu/jashing/core/eventsource/ScheduledEventSource.java
+++ b/jashing/src/main/java/com/github/avarabyeu/jashing/core/eventsource/ScheduledEventSource.java
@@ -13,6 +13,8 @@ import org.slf4j.helpers.MessageFormatter;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Objects.isNull;
+
 /**
  * Scheduled EventSource - produces events with specified time period.
  * Basically, based on Guava's {@link com.google.common.util.concurrent.AbstractScheduledService}
@@ -63,7 +65,7 @@ public abstract class ScheduledEventSource<T extends JashingEvent> extends Abstr
 
     protected final void sendEvent(JashingEvent t) {
         if (null != t) {
-            t.setId(eventId);
+            if (isNull(t.getId())) t.setId(eventId);
             this.eventBus.post(t);
         }
     }


### PR DESCRIPTION
Since sendEvent is a low level command, and produceEvent is tied to the main event type, removing this generics allow for more flexible events to be produced, like collateral events.